### PR TITLE
fix: handle non-numeric lastEventId in SSE connection

### DIFF
--- a/apps/api/src/modules/notification/websocket/sse.handler.ts
+++ b/apps/api/src/modules/notification/websocket/sse.handler.ts
@@ -46,7 +46,8 @@ export async function handleSSEConnection(
   }
 
   const query = request.query as Record<string, string>;
-  const lastEventId = parseInt(query['lastEventId'] ?? '0', 10);
+  const parsedLastEventId = parseInt(query['lastEventId'] ?? '0', 10);
+  const lastEventId = Number.isNaN(parsedLastEventId) ? 0 : parsedLastEventId;
   sseResponse.sequence = lastEventId;
 
   const initialEvent = createSSEEvent(


### PR DESCRIPTION
Fixes #2149

When lastEventId is non-numeric, parseInt returns NaN and sequence gets set to an invalid value. This falls back to 0 so SSE sequencing stays valid.

Greetings, saschabuehrle