### PR TITLE
fix: fix CI pipeline — Docker push, Trivy scanner, k6, remove OWASP Maven

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,50 +53,6 @@ jobs:
           echo "Dependency audit failed due to high/critical vulnerabilities."
           exit 1
 
-  owasp-dependency-check:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node: [22.x]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - name: Cache OWASP dependency-check
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository/org/owasp/dependency-check
-          key: owasp-${{ runner.os }}-6.8.1
-          restore-keys: |
-            owasp-${{ runner.os }}-
-      - name: Run OWASP Dependency-Check
-        run: |
-          mkdir -p security-reports
-          mvn org.owasp:dependency-check-maven:6.8.1:check \
-            -DoutputDirectory=security-reports \
-            -Dformat=HTML \
-            -Dformat=JSON \
-            -DfailBuildOnCVSS=7 \
-            -DsuppressionFile=.owasp-dependency-check-suppressions.xml \
-            -DassemblyArtifactEnabled=false
-      - name: Upload OWASP Dependency-Check results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: owasp-dependency-check-${{ matrix.node }}
-          path: security-reports/dependency-check*
-          if-no-files-found: warn
-      - name: Upload SARIF results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: security-reports/dependency-check.sarif
-          category: owasp-dependency-check
-
   lint-and-typecheck:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,7 @@ concurrency:
 permissions:
   contents: read
   security-events: write
+  packages: write
 
 jobs:
   build-images:
@@ -27,6 +28,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Login to GitHub Container Registry
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build API image
         run: |
           docker build \
@@ -35,6 +44,12 @@ jobs:
             -t ghcr.io/${{ env.OWNER_LC }}/the-dmz-api:latest \
             .
 
+      - name: Push API image
+        if: github.event_name == 'push'
+        run: |
+          docker push ghcr.io/${{ env.OWNER_LC }}/the-dmz-api:${{ github.sha }}
+          docker push ghcr.io/${{ env.OWNER_LC }}/the-dmz-api:latest
+
       - name: Build Web image
         run: |
           docker build \
@@ -42,6 +57,12 @@ jobs:
             -t ghcr.io/${{ env.OWNER_LC }}/the-dmz-web:${{ github.sha }} \
             -t ghcr.io/${{ env.OWNER_LC }}/the-dmz-web:latest \
             .
+
+      - name: Push Web image
+        if: github.event_name == 'push'
+        run: |
+          docker push ghcr.io/${{ env.OWNER_LC }}/the-dmz-web:${{ github.sha }}
+          docker push ghcr.io/${{ env.OWNER_LC }}/the-dmz-web:latest
 
   trivy-scan:
     needs: build-images
@@ -68,11 +89,11 @@ jobs:
             -f apps/web/Dockerfile \
             -t ghcr.io/${{ env.OWNER_LC }}/the-dmz-web:scan .
 
-      - name: Run Trivy vulnerability scanner
+      - name: Run Trivy vulnerability scanner (API)
         uses: aquasecurity/trivy-action@master
         with:
           scan-type: 'image'
-          scan-ref: '.'
+          image-ref: 'ghcr.io/${{ env.OWNER_LC }}/the-dmz-api:scan'
           format: 'sarif'
           output: 'trivy-results.sarif'
 
@@ -82,11 +103,11 @@ jobs:
           sarif_file: trivy-results.sarif
           category: trivy-container-scan
 
-      - name: Run Trivy vulnerability scanner (exit code)
+      - name: Run Trivy vulnerability scanner (Web)
         uses: aquasecurity/trivy-action@master
         with:
           scan-type: 'image'
-          scan-ref: '.'
+          image-ref: 'ghcr.io/${{ env.OWNER_LC }}/the-dmz-web:scan'
           severity: 'CRITICAL,HIGH'
           exit-code: '1'
           ignore-unfixed: true

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -39,6 +39,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -51,8 +56,18 @@ jobs:
       - name: Build shared package
         run: pnpm --filter @the-dmz/shared build
 
+      - name: Install k6
+        run: |
+          sudo gpg -k
+          sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+          echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+          sudo apt-get update
+          sudo apt-get install k6 -y
+
       - name: Start services
         run: docker compose up -d
+        env:
+          POSTGRES_PASSWORD: test-ci-password
 
       - name: Wait for services
         run: sleep 15


### PR DESCRIPTION
## Summary
- **docker.yml**: Add GHCR login (`docker/login-action@v3`) and `docker push` steps so built images are actually published to the registry. Previously, images were tagged for `ghcr.io` but never pushed — every build produced zero persistent artifacts
- **docker.yml**: Fix Trivy container vulnerability scanner — `scan-type: 'image'` requires `image-ref` (image name), not `scan-ref: '.'` (filesystem path). Split into separate API and Web image scans
- **load-tests.yml**: Add `pnpm/action-setup@v4` (pnpm was missing, causing `cache: pnpm` to fail) and install k6 via apt (k6 is a Go binary, not available via npx)
- **load-tests.yml**: Add `POSTGRES_PASSWORD` env var to `docker compose up` step
- **ci.yml**: Remove `owasp-dependency-check` job that runs Maven (`mvn org.owasp:dependency-check-maven:6.8.1:check`) against a project with no `pom.xml` — always fails. Node.js vulnerability scanning is already covered by `pnpm audit` in the `dependency-audit` job

Closes #2005

## Test plan
- [ ] Docker workflow builds and pushes images on push to master
- [ ] Trivy scans actual container images (not filesystem)
- [ ] Load test workflow installs pnpm and k6 successfully
- [ ] CI pipeline passes without the broken OWASP Maven job