### PR TITLE
fix: harden prototype poisoning, CSRF timing, and JWT lifetime

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -149,8 +149,8 @@ export const buildApp = async (
     requestIdHeader: 'x-request-id',
     genReqId: (request) => resolveRequestId(request.headers['x-request-id']) ?? generateId(),
     bodyLimit: config.MAX_BODY_SIZE,
-    onProtoPoisoning: 'ignore',
-    onConstructorPoisoning: 'ignore',
+    onProtoPoisoning: 'error',
+    onConstructorPoisoning: 'error',
   });
 
   app.decorate('config', config);

--- a/apps/api/src/modules/auth/csrf.ts
+++ b/apps/api/src/modules/auth/csrf.ts
@@ -1,3 +1,5 @@
+import { timingSafeEqual } from 'node:crypto';
+
 import { AppError, ErrorCodes } from '../../shared/middleware/error-handler.js';
 
 import type {
@@ -51,7 +53,10 @@ export const validateCsrf: preHandlerAsyncHookHandler = async (
     });
   }
 
-  if (cookieToken !== headerToken) {
+  if (
+    cookieToken.length !== headerToken.length ||
+    !timingSafeEqual(Buffer.from(cookieToken), Buffer.from(headerToken))
+  ) {
     throw new AppError({
       code: ErrorCodes.AUTH_CSRF_INVALID,
       message: 'CSRF token invalid',

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -103,7 +103,7 @@ export const backendEnvSchema = z
     REDIS_URL: z.string().min(1).default('redis://localhost:6379'),
     LOG_LEVEL: z.enum(logLevelValues).default('info'),
     JWT_SECRET: z.string().min(1).default('dev-test-jwt-secret'),
-    JWT_EXPIRES_IN: z.string().min(1).default('7d'),
+    JWT_EXPIRES_IN: z.string().min(1).default('15m'),
     JWT_ISSUER: z.string().min(1).default('https://the-dmz.local'),
     JWT_AUDIENCE: z.string().min(1).default('the-dmz-api'),
     TOKEN_HASH_SALT: z.string().min(1).default('token-hash-dev-test-salt'),


### PR DESCRIPTION
## Summary
- Re-enable Fastify prototype poisoning protection (`onProtoPoisoning: 'error'`) — was set to `'ignore'`, bypassing framework-level defense against `__proto__` injection
- Use `crypto.timingSafeEqual` for CSRF token comparison to prevent timing side-channel attacks
- Reduce default JWT access token lifetime from 7 days to 15 minutes — the existing refresh token flow handles session continuity

## Related Issues
- Addresses prototype pollution risk identified in security audit
- CSRF timing attack mitigation (OWASP A02)
- JWT lifetime aligns with OWASP session management guidelines

## Test plan
- [ ] Verify API starts without errors
- [ ] Verify CSRF validation still works for valid tokens
- [ ] Verify CSRF rejects mismatched tokens
- [ ] Verify JWT tokens expire after 15 minutes
- [ ] Verify refresh token flow extends sessions correctly