### PR TITLE
fix: correct analytics pgSchema, compliance UUID defaults, and audit indexes

### DIFF
--- a/apps/api/src/db/schema/analytics/index.ts
+++ b/apps/api/src/db/schema/analytics/index.ts
@@ -3,7 +3,7 @@ import {
   index,
   integer,
   jsonb,
-  pgTable,
+  pgSchema,
   real,
   text,
   timestamp,
@@ -11,8 +11,10 @@ import {
   varchar,
 } from 'drizzle-orm/pg-core';
 
-export const analyticsEvents = pgTable(
-  'analytics.events',
+const analyticsSchema = pgSchema('analytics');
+
+export const analyticsEvents = analyticsSchema.table(
+  'events',
   {
     eventId: uuid('event_id').primaryKey(),
     correlationId: uuid('correlation_id').notNull(),
@@ -44,8 +46,8 @@ export const analyticsEvents = pgTable(
 export type AnalyticsEvent = typeof analyticsEvents.$inferSelect;
 export type NewAnalyticsEvent = typeof analyticsEvents.$inferInsert;
 
-export const playerProfiles = pgTable(
-  'analytics.player_profiles',
+export const playerProfiles = analyticsSchema.table(
+  'player_profiles',
   {
     userId: uuid('user_id').primaryKey(),
     tenantId: uuid('tenant_id').notNull(),
@@ -78,8 +80,8 @@ export const playerProfiles = pgTable(
 export type PlayerProfile = typeof playerProfiles.$inferSelect;
 export type NewPlayerProfile = typeof playerProfiles.$inferInsert;
 
-export const deadLetterQueue = pgTable(
-  'analytics.dead_letter_queue',
+export const deadLetterQueue = analyticsSchema.table(
+  'dead_letter_queue',
   {
     id: uuid('id')
       .primaryKey()
@@ -102,8 +104,8 @@ export const deadLetterQueue = pgTable(
 export type DeadLetterQueueItem = typeof deadLetterQueue.$inferSelect;
 export type NewDeadLetterQueueItem = typeof deadLetterQueue.$inferInsert;
 
-export const analyticsMetrics = pgTable(
-  'analytics.metrics',
+export const analyticsMetrics = analyticsSchema.table(
+  'metrics',
   {
     id: uuid('id')
       .primaryKey()
@@ -125,8 +127,8 @@ export const analyticsMetrics = pgTable(
 export type AnalyticsMetric = typeof analyticsMetrics.$inferSelect;
 export type NewAnalyticsMetric = typeof analyticsMetrics.$inferInsert;
 
-export const retentionCohorts = pgTable(
-  'analytics.retention_cohorts',
+export const retentionCohorts = analyticsSchema.table(
+  'retention_cohorts',
   {
     id: uuid('id')
       .primaryKey()
@@ -161,8 +163,8 @@ export const retentionCohorts = pgTable(
 export type RetentionCohort = typeof retentionCohorts.$inferSelect;
 export type NewRetentionCohort = typeof retentionCohorts.$inferInsert;
 
-export const pseudonymizationMappings = pgTable(
-  'analytics.pseudonymization_mappings',
+export const pseudonymizationMappings = analyticsSchema.table(
+  'pseudonymization_mappings',
   {
     id: uuid('id')
       .primaryKey()

--- a/apps/api/src/db/schema/audit/index.ts
+++ b/apps/api/src/db/schema/audit/index.ts
@@ -1,5 +1,6 @@
 import { sql } from 'drizzle-orm';
 import {
+  index,
   integer,
   jsonb,
   pgSchema,
@@ -39,18 +40,18 @@ export const auditLogs = auditSchema.table(
     userAgent: varchar('user_agent', { length: 512 }),
   },
   (table) => ({
-    tenantIdPartitionMonth: uniqueIndex('audit_logs_tenant_partition_idx').on(
+    tenantIdPartitionMonth: index('audit_logs_tenant_partition_idx').on(
       table.tenantId,
       table.partitionMonth,
     ),
-    tenantIdTimestamp: uniqueIndex('audit_logs_tenant_timestamp_idx').on(
+    tenantIdTimestamp: index('audit_logs_tenant_timestamp_idx').on(
       table.tenantId,
       table.timestamp,
       table.id,
     ),
-    tenantIdAction: uniqueIndex('audit_logs_tenant_action_idx').on(table.tenantId, table.action),
-    tenantIdUserId: uniqueIndex('audit_logs_tenant_user_idx').on(table.tenantId, table.userId),
-    tenantIdResource: uniqueIndex('audit_logs_tenant_resource_idx').on(
+    tenantIdAction: index('audit_logs_tenant_action_idx').on(table.tenantId, table.action),
+    tenantIdUserId: index('audit_logs_tenant_user_idx').on(table.tenantId, table.userId),
+    tenantIdResource: index('audit_logs_tenant_resource_idx').on(
       table.tenantId,
       table.resourceType,
       table.resourceId,

--- a/apps/api/src/db/schema/compliance/index.ts
+++ b/apps/api/src/db/schema/compliance/index.ts
@@ -1,3 +1,4 @@
+import { sql } from 'drizzle-orm';
 import {
   index,
   integer,
@@ -17,7 +18,7 @@ export const complianceSnapshots = complianceSchema.table(
   {
     id: uuid('id')
       .primaryKey()
-      .default({} as never),
+      .default(sql`uuid_generate_v7()`),
     tenantId: uuid('tenant_id').notNull(),
     frameworkId: varchar('framework_id', { length: 32 }).notNull(),
     status: varchar('status', { length: 32 }).notNull().default('not_started'),
@@ -49,7 +50,7 @@ export const frameworkRequirements = complianceSchema.table(
   {
     id: uuid('id')
       .primaryKey()
-      .default({} as never),
+      .default(sql`uuid_generate_v7()`),
     tenantId: uuid('tenant_id').notNull(),
     frameworkId: varchar('framework_id', { length: 32 }).notNull(),
     requirementId: varchar('requirement_id', { length: 64 }).notNull(),


### PR DESCRIPTION
## Summary
- **Analytics schema**: Tables were registered as `pgTable('analytics.events')` creating a table literally named `"analytics.events"` in the `public` schema. Changed to `pgSchema('analytics').table('events')` to correctly place tables in the `analytics` PostgreSQL schema — aligning with the pattern used by all other domain schemas (auth, social, audit, etc.)
- **Compliance schema**: Both `compliance_snapshots` and `framework_requirements` used `.default({} as never)` as UUID primary key default — a TypeScript type hack that generates no valid SQL default, causing INSERT failures. Replaced with `sql\`uuid_generate_v7()\`` matching the project-wide convention
- **Audit schema**: 5 performance indexes on `audit.logs` were declared as `uniqueIndex` instead of `index`, preventing more than one audit log entry per `(tenant_id, action)` or `(tenant_id, user_id)` combination — effectively breaking the audit trail

## Test plan
- [ ] TypeScript compilation passes (`pnpm typecheck`)
- [ ] Existing schema tests pass
- [ ] Verify analytics tables are queried in the correct PostgreSQL schema
- [ ] Verify compliance table inserts work without explicit ID
- [ ] Verify audit log allows multiple entries per tenant/action