### PR TITLE
fix: incident schema validation prevents API startup

### DIFF
--- a/apps/api/src/modules/game/incident/incident.schemas.ts
+++ b/apps/api/src/modules/game/incident/incident.schemas.ts
@@ -35,11 +35,11 @@ export const incidentSchema = z.object({
   incidentId: z.string().uuid(),
   sessionId: z.string().uuid(),
   attackId: z.string().uuid().nullable().optional(),
-  timestamp: z.string().or(z.date()),
+  timestamp: z.string(),
   day: z.number(),
   detectionSource: z.enum(DETECTION_SOURCES),
   classification: z.enum(INCIDENT_CLASSIFICATIONS),
-  severity: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)]),
+  severity: z.number().int().min(1).max(4),
   affectedAssets: z.array(z.string()),
   evidence: incidentEvidenceSchema,
   status: z.enum(INCIDENT_STATUSES),
@@ -48,10 +48,10 @@ export const incidentSchema = z.object({
   outcome: z.string().optional(),
   rootCause: z.string().optional(),
   lessonsLearned: z.string().optional(),
-  resolvedAt: z.string().or(z.date()).optional(),
+  resolvedAt: z.string().optional(),
   resolutionDays: z.number().nullable().optional(),
-  createdAt: z.string().or(z.date()).optional(),
-  updatedAt: z.string().or(z.date()).optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
 });
 
 export const incidentListResponseSchema = z.object({


### PR DESCRIPTION
## Summary
Fixes API startup crash: `Failed building the validation schema for GET: /api/v1/game/sessions/:sessionId/incidents, due to error schema is invalid: data/required must be array`

The incident route schemas used Zod types that produce invalid JSON Schema when Fastify processes them:
- `z.string().or(z.date())` → replaced with `z.string()` (dates arrive as ISO strings over HTTP)
- `z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)])` → replaced with `z.number().int().min(1).max(4)`

One file changed, 5 lines.

## Test plan
- [x] API starts without schema validation errors
- [x] GET /api/v1/game/sessions/:sessionId/incidents responds correctly
- [ ] Incident severity validation still rejects values outside 1-4